### PR TITLE
Spring Data JPA and SQLite Driver integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,14 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
-
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.datasource.url=jdbc:sqlite:app.db
+spring.datasource.driver-class-name=org.sqlite.JDBC
+spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.SQLiteDialect


### PR DESCRIPTION
### Description
Installed Spring Data JPA and SQLite drivers with properties. You can find out all of the properties below.

```
spring.jpa.hibernate.ddl-auto=create-drop
spring.datasource.url=jdbc:sqlite:app.db
spring.datasource.driver-class-name=org.sqlite.JDBC
spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.SQLiteDialect
```